### PR TITLE
Add PdfFileHandler for PDF file type support

### DIFF
--- a/src/Application/FileInput/Base64FileInput.php
+++ b/src/Application/FileInput/Base64FileInput.php
@@ -49,6 +49,7 @@ class Base64FileInput implements FileInput
             'image/gif' => 'gif',
             'image/avif' => 'avif',
             'image/svg+xml' => 'svg',
+            'application/pdf' => 'pdf',
             default => 'bin',
         };
     }

--- a/src/Application/FileRouter/PdfFileHandler.php
+++ b/src/Application/FileRouter/PdfFileHandler.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace M2code\FileManager\Application\FileRouter;
+
+use M2code\FileManager\Application\FileInput\FileInput;
+use M2code\FileManager\Domain\Contracts\FileSaver;
+use M2code\FileManager\Domain\Contracts\FileTypeHandler;
+use M2code\FileManager\DTO\FileOperationResult;
+
+class PdfFileHandler implements FileTypeHandler
+{
+    public function __construct(protected FileSaver $driver) {}
+
+    public function canHandle(FileInput $input): bool
+    {
+        return strtolower($input->getMimeType()) === 'application/pdf';
+    }
+
+    public function handleSave(FileInput $input, string $folder): FileOperationResult
+    {
+        return $this->driver->save($input, $folder);
+    }
+}

--- a/src/FileManagerServiceProvider.php
+++ b/src/FileManagerServiceProvider.php
@@ -6,6 +6,7 @@ use Illuminate\Support\ServiceProvider;
 use M2code\FileManager\Application\FileManagerService;
 use M2code\FileManager\Application\FileRouter\FileTypeRouterService;
 use M2code\FileManager\Application\FileRouter\ImageFileHandler;
+use M2code\FileManager\Application\FileRouter\PdfFileHandler;
 use M2code\FileManager\Application\FileRouter\SvgFileHandler;
 use M2code\FileManager\Application\Image\Actions\ApplyWatermarkAction;
 use M2code\FileManager\Application\Image\Actions\GenerateBlurAction;
@@ -33,6 +34,7 @@ class FileManagerServiceProvider extends ServiceProvider
 
             return new FileTypeRouterService([
                 new SvgFileHandler($driver),
+                new PdfFileHandler($driver),
                 new ImageFileHandler($driver),
 
                 // Other handlers

--- a/src/Support/FileExtensionHelper.php
+++ b/src/Support/FileExtensionHelper.php
@@ -41,6 +41,7 @@ class FileExtensionHelper
             'image/webp' => 'webp',
             'image/gif' => 'gif',
             'image/avif' => 'avif',
+            'application/pdf' => 'pdf',
             default => 'bin',
         };
     }

--- a/src/tests/Feature/FileSaverTest.php
+++ b/src/tests/Feature/FileSaverTest.php
@@ -82,6 +82,34 @@ class FileSaverTest extends TestCase
     }
 
     #[Test]
+    public function test_it_can_save_pdf_file()
+    {
+        Storage::fake('public');
+
+        $file = UploadedFile::fake()->create('document.pdf', 100, 'application/pdf');
+        $result = FileManager::save($file, 'testing');
+
+        self::assertNotNull($result->filePath);
+        self::assertStringEndsWith('.pdf', $result->filePath);
+        Storage::disk('public')->assertExists($result->filePath);
+    }
+
+    #[Test]
+    public function test_it_can_save_data_uri_pdf()
+    {
+        Storage::fake('public');
+
+        $pdfContent = '%PDF-1.4 test content';
+        $dataUri = 'data:application/pdf;base64,' . base64_encode($pdfContent);
+
+        $result = FileManager::save($dataUri, 'testing');
+
+        self::assertNotNull($result->filePath);
+        self::assertStringEndsWith('.pdf', $result->filePath);
+        Storage::disk('public')->assertExists($result->filePath);
+    }
+
+    #[Test]
     public function test_it_cannot_save_file_with_no_available_handler()
     {
         Storage::fake('public');


### PR DESCRIPTION
## Changes
- Add PdfFileHandler for handling `application/pdf` MIME type
- Register PdfFileHandler in FileManagerServiceProvider
- Update MIME-to-extension maps in FileExtensionHelper and Base64FileInput
- Add tests for PDF upload via UploadedFile and base64 data URI